### PR TITLE
buffer queues added

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@
 *.exe
 *.out
 *.app
+
+dataset

--- a/include/rio/common.h
+++ b/include/rio/common.h
@@ -133,9 +133,8 @@ struct CfarDetection {
   }
 };
 
-std::vector<CfarDetection> parseRadarMsg(
+std::vector<CfarDetection> parseRadarMsgRioDataset(
     const sensor_msgs::PointCloud2Ptr& msg);
-
 double computeBaroHeight(double pressure);
 
 }  // namespace rio

--- a/include/rio/rio.h
+++ b/include/rio/rio.h
@@ -72,6 +72,8 @@ class Rio {
   void imuFilterCallback(const sensor_msgs::ImuConstPtr& msg);
   void cfarDetectionsCallback(const sensor_msgs::PointCloud2Ptr& msg);
   void pressureCallback(const sensor_msgs::FluidPressurePtr& msg);
+  void processIMUMeasurements(const sensor_msgs::ImuConstPtr& msg);
+  void processRadarFrames();
 
   ros::Publisher odom_navigation_pub_;
   ros::Publisher odom_optimizer_pub_;
@@ -107,5 +109,10 @@ class Rio {
   bool baro_active_{false};
   std::optional<double> baro_height_bias_;
   std::deque<std::pair<double, double>> baro_height_bias_history_;
+
+  std::deque<sensor_msgs::ImuConstPtr> imu_queue;
+  std::deque<sensor_msgs::PointCloud2Ptr> radar_queue;
+
+  std::string dataset_ = "rio";
 };
 }  // namespace rio

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -213,7 +213,7 @@ bool rio::loadNoiseRadarTrack(const ros::NodeHandle& nh,
   return true;
 }
 
-std::vector<CfarDetection> rio::parseRadarMsg(
+std::vector<CfarDetection> rio::parseRadarMsgRioDataset(
     const sensor_msgs::PointCloud2Ptr& msg) {
   std::vector<CfarDetection> detections(msg->height * msg->width);
   sensor_msgs::PointCloud2Iterator<float> iter_x(*msg, "x");

--- a/src/rio_calibration_node.cpp
+++ b/src/rio_calibration_node.cpp
@@ -170,7 +170,7 @@ int main(int argc, char** argv) {
     } else if (msg.getTopic() == radar_topic) {
       sensor_msgs::PointCloud2Ptr radar_msg =
           msg.instantiate<sensor_msgs::PointCloud2>();
-      auto detections = parseRadarMsg(radar_msg);
+      auto detections = parseRadarMsgRioDataset(radar_msg);
       RadarMeasurement radar_measurement;
       radar_measurement.t = radar_msg->header.stamp.toSec();
       for (const auto& detection : detections) {


### PR DESCRIPTION
Added buffering queues for datasets with unaligned timestamps between radar & imu. 
It has been tested with the snail-dataset but the pull request corresponds only to the queueing, no other datasets are currently implemented :)

Also no changes were done to the baro/pressure code, so it's not verified that it works properly.

